### PR TITLE
make smpc button active only if smpc content exists

### DIFF
--- a/code/pages/drug-details.html
+++ b/code/pages/drug-details.html
@@ -73,28 +73,32 @@
                 </section>
             </psk-details>
 
-            <psk-layout align-items="center" class="topPadding" row-gap="30px" template-columns="1fr 1fr">
+            <psk-layout template-columns="1fr 1fr" align-items="center" row-gap="30px" class="topPadding">
                 <psk-layout-item class="controlButton">
-                    <psk-button-link class="xxlIcon" event-name="view-leaflet" icon="file-text"
-                                     name="Patient Information">
+                    <psk-button-link class="xxlIcon active" name="Patient Information" icon="file-text" event-name="view-leaflet">
                     </psk-button-link>
                 </psk-layout-item>
                 <psk-layout-item class="controlButton">
-                    <psk-button-link class="xxlIcon smpc" event-name="view-smpc" icon="book"
-                                     name="SmPC"></psk-button-link>
+                    <psk-condition condition="isSmpc">
+                        <div slot="condition-true">
+                            <psk-button-link class="xxlIcon active" name="SmPC" icon="book" event-name="view-smpc"></psk-button-link>
+                        </div>
+                        <div slot="condition-false" style="pointer-events:none;">
+                            <psk-button-link class="xxlIcon inactive" name="SmPC" icon="book" disabled></psk-button-link>
+                        </div>
+                    </psk-condition>
                 </psk-layout-item>
             </psk-layout>
 
-            <psk-layout align-items="center" class="topPadding" row-gap="30px" template-columns="1fr 1fr 1fr">
+            <psk-layout template-columns="1fr 1fr 1fr" align-items="center" row-gap="30px" class="topPadding">
                 <psk-layout-item class="controlButton">
-                    <psk-button-link class="xlIcon" disabled icon="info-circle" name="Verify package"></psk-button-link>
+                    <psk-button-link class="xlIcon inactive" name="Verify package" icon="info-circle" disabled></psk-button-link>
                 </psk-layout-item>
                 <psk-layout-item class="controlButton">
-                    <psk-button-link class="xlIcon" disabled icon="exclamation-triangle"
-                                     name="Report"></psk-button-link>
+                    <psk-button-link class="xlIcon inactive" name="Report" icon="exclamation-triangle" disabled></psk-button-link>
                 </psk-layout-item>
                 <psk-layout-item class="controlButton">
-                    <psk-button-link class="xlIcon" disabled icon="archive" name="Add to cabinet"></psk-button-link>
+                    <psk-button-link class="xlIcon inactive" name="Add to cabinet" icon="archive" disabled></psk-button-link>
                 </psk-layout-item>
             </psk-layout>
 

--- a/code/scripts/controllers/DrugDetailsController.js
+++ b/code/scripts/controllers/DrugDetailsController.js
@@ -2,6 +2,7 @@ import ContainerController from "../../cardinal/controllers/base-controllers/Con
 import utils from "../../utils.js";
 import DSUDataRetrievalService from "../services/DSUDataRetrievalService/DSUDataRetrievalService.js";
 import constants from "../../constants.js";
+import XMLDisplayService from "../services/XMLDisplayService/XMLDisplayService.js";
 
 export default class DrugDetailsController extends ContainerController {
   constructor(element, history) {
@@ -34,6 +35,9 @@ export default class DrugDetailsController extends ContainerController {
 
     this.model.PVIcon = constants.PACK_VERIFICATION_ICON;
     this.setColor('packageVerification', 'orange');
+
+    const smpcDisplayService = new XMLDisplayService(this.DSUStorage, element, this.gtinSSI, basePath, "smpc", "smpc.xml", this.model);
+    smpcDisplayService.isXmlAvailable()
 
     this.on("view-leaflet", () => {
       history.push({

--- a/code/scripts/services/XMLDisplayService/XMLDisplayService.js
+++ b/code/scripts/services/XMLDisplayService/XMLDisplayService.js
@@ -41,6 +41,12 @@ export default class XmlDisplayService {
         })
     }
 
+    isXmlAvailable() {
+        this.getAvailableLanguagesForXmlType((err, languages) => {
+            this.model.isSmpc = languages.length > 0;
+        });
+    }
+
     populateModel() {
         this.getAvailableLanguagesForXmlType((err, languages) => {
             this.languageService.addWorkingLanguages(languages, (err) => {


### PR DESCRIPTION
This change allow changing the SmPC button on the drug details screen to appear inactive if not SmPC document has been uploaded.

Pre-requisite to approve: https://github.com/PharmaLedger-IMI/epi-theme/pull/2