### PR TITLE
Refs14 acdc

### DIFF
--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -8,9 +8,10 @@ const utils = gtinResolver.utils;
 export default class AuthFeatureController extends WebcController {
   constructor(element, history, ...args) {
     super(element, history, ...args);
-    if (!history.location.state)
-      return console.log(`ERROR: No state found for Auth Feature`);
-    const {ssi, gs1Fields, gtinSSI, acdc, networkName} = history.location.state;
+    // if (!history.location.state)
+    //   return console.log(`ERROR: No state found for Auth Feature`);
+    // const {ssi, gs1Fields, gtinSSI, acdc, networkName} = history.location.state;
+    const {ssi, gs1Fields, gtinSSI, acdc, networkName} = this.model;
     gs1Fields.domain = networkName;
     this.model = {
       ssi: ssi,
@@ -28,10 +29,10 @@ export default class AuthFeatureController extends WebcController {
       this.settingsService = new SettingsService(enclaveDB);
       this.acdc = require('acdc').ReportingService.getInstance(this.settingsService);
 
-      this.on('windowAction', this.receiveAuthResponse.bind(this))
+      // this.on('windowAction', this.receiveAuthResponse.bind(this))
     })
 
-    // this.on('windowAction', this.receiveAuthResponse.bind(this));
+    this.on('windowAction', this.receiveAuthResponse.bind(this));
   }
 
   receiveAuthResponse(evt) {

--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -49,11 +49,26 @@ export default class AuthFeatureController extends WebcController {
     const acdc = Object.assign({}, this.model.acdc, {
       authResponse: authResponse
     })
-    this.navigateToPageTag('drug-details', {
+    
+    const result = {
       gs1Fields: Object.assign({}, this.model.gs1Fields),
       gtinSSI: this.model.gtinSSI,
       acdc: acdc
-    });
+    }
+    
+    // Since this is now a modal, I dont really know how I should return these results back to the Main Application.
+    // This was the former way
+    // this.navigateToPageTag('drug-details', results);
+    
+    // You could use an event... but regardless, the scanning and validation is done, the report has been sent. all is good
+    
+    // So now I just close the modal and log the results... 
+    const modal = this.element.closest('webc-modal');
+    
+    if (!modal)
+      console.errors("This should be impossible...");
+    modal.hide().then(_ => console.log("Results of Auth Feature:\n" + JSON.stringify(result, undefined, 2)))
+    
   }
 
   storeResults(authResponse, callback) {

--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -92,7 +92,9 @@ export default class AuthFeatureController extends WebcController {
   report(authResponse, callback) {
     const evt = this.acdc.createScanEvent(Object.assign({}, this.model.gs1Fields, {
       previousScan: this.model.acdc ? this.model.acdc.eventId : undefined,
-      authResponse: authResponse
+      authResponse: authResponse,
+      batchDsuStatus: this.model.acdc.batchDsuStatus,
+      productDsuStatus: this.model.acdc.productDsuStatus
     }));
     evt.report((err) => {
       if (err)

--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -62,7 +62,7 @@ export default class AuthFeatureController extends WebcController {
     self.dbStorage.getRecord(constants.HISTORY_TABLE, pk, (err, record) => {
       if (err)
         return callback(err);
-      record.acdc = Object.assign(record.acdc, {
+      record.acdc = Object.assign(record.acdc || {}, {
         authResponse: authResponse
       });
 

--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -13,12 +13,6 @@ export default class AuthFeatureController extends WebcController {
     // const {ssi, gs1Fields, gtinSSI, acdc, networkName} = history.location.state;
     const {ssi, gs1Fields, gtinSSI, acdc, networkName} = this.model;
     gs1Fields.domain = networkName;
-    this.model = {
-      ssi: ssi,
-      gtinSSI: gtinSSI,
-      gs1Fields: gs1Fields,
-      acdc: acdc
-    };
     let dbApi = require("opendsu").loadApi("db");
     dbApi.getMainEnclaveDB(async (err, enclaveDB) => {
       if (err) {
@@ -28,8 +22,6 @@ export default class AuthFeatureController extends WebcController {
       this.dbStorage = enclaveDB;
       this.settingsService = new SettingsService(enclaveDB);
       this.acdc = require('acdc').ReportingService.getInstance(this.settingsService);
-
-      // this.on('windowAction', this.receiveAuthResponse.bind(this))
     })
 
     this.on('windowAction', this.receiveAuthResponse.bind(this));

--- a/code/scripts/controllers/AuthFeatureController.js
+++ b/code/scripts/controllers/AuthFeatureController.js
@@ -28,9 +28,7 @@ export default class AuthFeatureController extends WebcController {
       this.settingsService = new SettingsService(enclaveDB);
       this.acdc = require('acdc').ReportingService.getInstance(this.settingsService);
 
-      this.on('windowAction', (result) => {
-        alert("Received acdc rezult: ", result);
-      })
+      this.on('windowAction', this.receiveAuthResponse.bind(this))
     })
 
     // this.on('windowAction', this.receiveAuthResponse.bind(this));

--- a/code/scripts/controllers/DrugDetailsController.js
+++ b/code/scripts/controllers/DrugDetailsController.js
@@ -24,7 +24,8 @@ export default class DrugDetailsController extends WebcController {
       selectUserType: false,
       preferredDocType: "",
       twoOrMoreLanguages: false,
-      documentLanguages: []
+      documentLanguages: [],
+      acdc: history.location.state.acdc
     };
 
     this.model.aboutLabel = this.translate("about")
@@ -291,7 +292,8 @@ export default class DrugDetailsController extends WebcController {
             ssi: this.model.batch.acdcAuthFeatureSSI,
             gtinSSI: this.gtinSSI,
             gs1Fields: this.gs1Fields,
-            networkName: this.networkName
+            networkName: this.networkName,
+            acdc: this.model.acdc
           },
           disableExpanding: true,
           disableFooter: true


### PR DESCRIPTION
for acdc integration.

needs also the PR in gtin resolver and epi-workspace.

the auth feature result is now relayed to the acdc address defined in the product.

restored control of application back to the DrugDetailsController but:
 - No data is passed back to the DrugDetailsController (this will probably have to be done via event because of the modal), since you are unsure on how to display this. the result is simply written to the console for confirmation.
 - Because of the new way you store data in the batches, and because there is no api to retrieve the latest batch info without knowing what the latest is, the ssi stored on batch creation is the only that will be read. this means that updating the auth feature ssi on a batch level does not work atm

